### PR TITLE
Fix config parsing

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -34,7 +34,6 @@ type Config struct {
 
 func Init(path string) {
 	var err error
-	var config Config
 
 	v := viper.New()
 	v.SetConfigType("yml")


### PR DESCRIPTION
There's another top-scope variable called `config`, we should use that one instead of the local one.