### PR TITLE
Fix r10k command execution

### DIFF
--- a/api/environment.go
+++ b/api/environment.go
@@ -42,8 +42,7 @@ func (e EnvironmentController) DeployEnvironment(c *gin.Context) {
 	}
 
 	cmd.Args = append(cmd.Args, env)
-
-	cmd.Args = append(cmd.Args, fmt.Sprintf("-c %s", h.GetR10kConfig()))
+	cmd.Args = append(cmd.Args, fmt.Sprintf("--config=%s", h.GetR10kConfig()))
 
 	if conf.Verbose {
 		cmd.Args = append(cmd.Args, "-v")

--- a/api/module.go
+++ b/api/module.go
@@ -38,8 +38,7 @@ func (m ModuleController) DeployModule(c *gin.Context) {
 	}
 
 	cmd.Args = append(cmd.Args, data.ModuleName)
-
-	cmd.Args = append(cmd.Args, fmt.Sprintf("-c %s", h.GetR10kConfig()))
+	cmd.Args = append(cmd.Args, fmt.Sprintf("--config=%s", h.GetR10kConfig()))
 
 	if conf.Verbose {
 		cmd.Args = append(cmd.Args, "-v")


### PR DESCRIPTION
Not sure why `--config` works and `-c` wasn't working. 
I was getting `cmd.Run() failed with error environment: option requires an argument -- c`