### PR TITLE
Fix basic auth not being configurable

### DIFF
--- a/server/router.go
+++ b/server/router.go
@@ -13,16 +13,22 @@ func NewRouter() *gin.Engine {
 	router := gin.New()
 	router.Use(gin.Logger())
 	router.Use(gin.Recovery())
-	user := users.Users{
-		User:     config.GetConfig().Server.User,
-		Password: config.GetConfig().Server.Password,
+
+	var apiHandlerFuncs []gin.HandlerFunc
+	if config.GetConfig().Server.Protected {
+		user := users.Users{
+			User:     config.GetConfig().Server.User,
+			Password: config.GetConfig().Server.Password,
+		}
+
+		apiHandlerFuncs = append(apiHandlerFuncs, gin.BasicAuth(gin.Accounts{user.User: user.Password}))
 	}
 
 	health := new(wapi.HealthController)
 
 	router.GET("/health", health.Status)
 
-	api := router.Group("api", gin.BasicAuth(gin.Accounts{user.User: user.Password}))
+	api := router.Group("api", apiHandlerFuncs...)
 	{
 		v1 := api.Group("v1")
 		{


### PR DESCRIPTION
On f08362493f139a270203ab9d911c07d19ba7aa3b basic auth was added but the `protected` option was never used, causing the webhook server to be always protected or panic if user and password were empty.

I added a `apiHandlerFunc` array in case we need to add more Handlers in the future.