### PR TITLE
Log errors returned by commands correctly

### DIFF
--- a/api/environment.go
+++ b/api/environment.go
@@ -79,7 +79,12 @@ func (e EnvironmentController) DeployEnvironment(c *gin.Context) {
 	//		* Respond with an HTTP 202 and the result in JSON format
 	res, err := execute(cmd)
 	if err != nil {
-		log.Errorf("orchestrator `%s` failed to execute command `%s` with error: `%s`", *conf.Orchestration.Type, cmd, err)
+		if conf.Orchestration.Enabled {
+			log.Errorf("orchestrator `%s` failed to execute command `%s` with error: `%s` `%s`", *conf.Orchestration.Type, cmd, err, res)
+		} else {
+			log.Errorf("failed to execute local command `%s` with error: `%s` `%s`", cmd, err, res)
+		}
+
 		c.JSON(http.StatusInternalServerError, res)
 		c.Abort()
 		if conf.ChatOps.Enabled {


### PR DESCRIPTION
`err` from `CombinedOutput` seems to return only the exit code, whereas `res` should return the actual error from the command.

Also, when orchestrator is disabled printing out `orchestrator %s failed to execute command %s with error` can be misleading for the user, so I wrapped that into `if conf.Orchestration.Enabled`.
This also fixes the panic when the user removes completely the `orchestrator` section from the config causing a null pointer dereference as `conf.Orchestration.Type` is nil.