### PR TITLE
Bugfix: remove redundant alias from systemd unit file

### DIFF
--- a/build/webhook-go.service
+++ b/build/webhook-go.service
@@ -11,4 +11,3 @@ KillMode=process
 
 [Install]
 WantedBy=multi-user.target
-Alias=webhook-go.service


### PR DESCRIPTION
The entry `Alias=webhook-go.service` in the shipped systemd unit file is redundant and let enabling the service at CentOS fail with:
```
[root@centos7-64-1 ~]# systemctl enable webhook-go
Failed to execute operation: Invalid argument
```
Removing that entry allows to enable the service.