### PR TITLE
Add a 'branch_only' parameter for /module

### DIFF
--- a/api/module.go
+++ b/api/module.go
@@ -42,6 +42,18 @@ func (m ModuleController) DeployModule(c *gin.Context) {
 		return
 	}
 
+	useBranch := c.Query("branch_only")
+	if useBranch != "" {
+		branch := ""
+		if data.Branch == "" {
+			branch = conf.R10k.DefaultBranch
+		} else {
+			branch = data.Branch
+		}
+		cmd = append(cmd, "-e")
+		cmd = append(cmd, branch)
+	}
+
 	// Append module name and r10k configuration to the cmd string slice
 	cmd = append(cmd, data.ModuleName)
 	cmd = append(cmd, fmt.Sprintf("--config=%s", h.GetR10kConfig()))


### PR DESCRIPTION
When passing this parameter, it tries to detect the branch from the module as well and apply it using the -e parameter to r10k. For modules that are branch-linked with the main repository, this will trigger an update *only* to the respective environment, rather than all environments.

* For pushes into a branch of the module corresponding to an environment, this merely saves processing time.
* For pushes to the default branch (of the module) which would affect all environments, this will block updates to all environments except for the default one (ie. production). This helps prevent unsolicited updates of an environment that could break it, until the environment itself is updated by other means (eg. by pushing into the respective branch of the source repository or module).