### PR TITLE
make module_name option optional

### DIFF
--- a/api/module.go
+++ b/api/module.go
@@ -58,13 +58,13 @@ func (m ModuleController) DeployModule(c *gin.Context) {
 	module := data.ModuleName
 	overrideModule := c.Query("module_name")
 	// Restrictions to Puppet module names are: 1) begin with lowercase letter, 2) contain lowercase, digits or underscores
-	match, _ := regexp.MatchString("^[a-z][a-z0-9_]*$", overrideModule)
-	if !match {
-		c.JSON(http.StatusInternalServerError, gin.H{"message": "Invalid module name"})
-		c.Abort()
-		return
-	}
 	if overrideModule != "" {
+		match, _ := regexp.MatchString("^[a-z][a-z0-9_]*$", overrideModule)
+		if !match {
+			c.JSON(http.StatusInternalServerError, gin.H{"message": "Invalid module name"})
+			c.Abort()
+			return
+		}
 		module = overrideModule
 	}
 


### PR DESCRIPTION
With PR #139 an option `module_name` was introduced to override the module name. This option is now mandatory, which I assume wasn't intended. This PR makes it optional.

Description:
Deploy module `my_module` without `?module_name`:
```
echo -e $(curl -s -u"r10kdeploy:DeployPass" -d '{ "project": { "name": "my_module" } }' -H 'Accept: application/json' -H 'X-Gitlab-Event: Push Hook' 'http://localhost:4000/api/v1/r10k/module')
```

Expected result:
```
"INFO	 -> Using Puppetfile '/etc/puppetlabs/code/environments/production/Puppetfile'
INFO	 -> Deploying module to /etc/puppetlabs/code/environments/production/modules/my_module
"
```

Actual result:
```
{"message":"Invalid module name"}
```

Explanation:
Matching for an invalid module name should only be done, when the option is given. Not giving the option, the variable `overrideModule` is an empty string, which does not match the RegEx, throwing the error.