### PR TITLE
add MS Teams to chatops

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Default: false
 #### `service`
 
 Type: string
-Description: Which service to use. Supported options: [`slack`, `rocketchat`]  
+Description: Which service to use. Supported options: [`slack`, `rocketchat`, `teams`]  
 Default: nil
 
 #### `channel`

--- a/README.md
+++ b/README.md
@@ -55,6 +55,27 @@ r10k:
   verbose: true
 ```
 
+### Microsoft Teams notifications
+
+Create an "Incoming Webhook" connector in Teams at the designated channel as described in the documentation: [Create Incoming Webhooks at learn.microsoft.com](https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook). Keep the URL confidential!
+
+Configure the service in the `webhook.yaml`:
+```yaml
+chatops:
+  enabled: true
+  service: teams
+  server_uri: "<Teams Webhook URI>"
+```
+
+Notifications are colored, according to their status.
+green: Success
+red: Failure
+orange: Warning
+
+Press the `Details` button to get more information.
+
+If the queue is enabled in the `server` part of `webhook.yaml`, then two notifications are emitted: First, when the request is added to the queue and second, when the request was processed.
+
 ### Bolt authentication
 
 Due to the inherent security risk associated with passing plain text passwords to the Bolt CLI tool, all ability to set it within the application have been removed.
@@ -169,7 +190,7 @@ Default: nil
 #### `server_uri`
 
 Type: string  
-Description: The ChatOps service API URI to send the message to.  
+Description: The ChatOps service API URI to send the message to. For MS Teams, this is the Webhook URL created at the channel connectors.
 Default: nil
 
 ### r10k options

--- a/api/environment.go
+++ b/api/environment.go
@@ -97,14 +97,14 @@ func (e EnvironmentController) DeployEnvironment(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, res)
 		c.Abort()
 		if conf.ChatOps.Enabled {
-			conn.PostMessage(http.StatusInternalServerError, env)
+			conn.PostMessage(http.StatusInternalServerError, env, res)
 		}
 		return
 	}
 
 	c.JSON(http.StatusAccepted, res)
 	if conf.ChatOps.Enabled {
-		conn.PostMessage(http.StatusAccepted, env)
+		conn.PostMessage(http.StatusAccepted, env, res)
 	}
 
 }

--- a/api/module.go
+++ b/api/module.go
@@ -38,7 +38,7 @@ func (m ModuleController) DeployModule(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"message": "Error Parsing Webhook", "error": err})
 		c.Abort()
 		if conf.ChatOps.Enabled {
-			conn.PostMessage(http.StatusInternalServerError, "Error Parsing Webhook")
+			conn.PostMessage(http.StatusInternalServerError, "Error Parsing Webhook", err)
 		}
 		return
 	}
@@ -63,6 +63,10 @@ func (m ModuleController) DeployModule(c *gin.Context) {
 		if !match {
 			c.JSON(http.StatusInternalServerError, gin.H{"message": "Invalid module name"})
 			c.Abort()
+			err = fmt.Errorf("invalid module name: module name does not match the expected pattern; got: %s, pattern: ^[a-z][a-z0-9_]*$", overrideModule)
+			if conf.ChatOps.Enabled {
+				conn.PostMessage(http.StatusInternalServerError, "Invalid module name", err)
+			}
 			return
 		}
 		module = overrideModule
@@ -103,13 +107,13 @@ func (m ModuleController) DeployModule(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, res)
 		c.Abort()
 		if conf.ChatOps.Enabled {
-			conn.PostMessage(http.StatusInternalServerError, data.ModuleName)
+			conn.PostMessage(http.StatusInternalServerError, data.ModuleName, err)
 		}
 		return
 	}
 
 	c.JSON(http.StatusAccepted, res)
 	if conf.ChatOps.Enabled {
-		conn.PostMessage(http.StatusAccepted, data.ModuleName)
+		conn.PostMessage(http.StatusAccepted, data.ModuleName, res)
 	}
 }

--- a/api/module.go
+++ b/api/module.go
@@ -107,7 +107,7 @@ func (m ModuleController) DeployModule(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, res)
 		c.Abort()
 		if conf.ChatOps.Enabled {
-			conn.PostMessage(http.StatusInternalServerError, data.ModuleName, err)
+			conn.PostMessage(http.StatusInternalServerError, data.ModuleName, res)
 		}
 		return
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	code.gitea.io/gitea/modules/structs v0.0.0-20190610152049-835b53fc259c
+	github.com/atc0005/go-teams-notify/v2 v2.10.0
 	github.com/gin-gonic/gin v1.10.0
 	github.com/go-playground/webhooks/v6 v6.3.0
 	github.com/google/go-github/v39 v39.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 code.gitea.io/gitea/modules/structs v0.0.0-20190610152049-835b53fc259c h1:WwxK+8qmKYgU2pfcbCeRSqKwEPeHnW/sfmNc6pjLZC8=
 code.gitea.io/gitea/modules/structs v0.0.0-20190610152049-835b53fc259c/go.mod h1:e/Ukqo229PbsSEymXfLWmNz4g04hwnFml5lW6U+0Azs=
+github.com/atc0005/go-teams-notify/v2 v2.10.0 h1:eQvRIkyESQgBvlUdQ/iPol/lj3QcRyrdEQM3+c/nXhM=
+github.com/atc0005/go-teams-notify/v2 v2.10.0/go.mod h1:SIeE1UfCcVRYMqP5b+r1ZteHyA/2UAjzWF5COnZ8q0w=
 github.com/bytedance/sonic v1.11.6 h1:oUp34TzMlL+OY1OUWxHqsdkgC/Zfc85zGqw9siXjrc0=
 github.com/bytedance/sonic v1.11.6/go.mod h1:LysEHSvpvDySVdC2f87zGWf6CIKJcAvqab1ZaiQtds4=
 github.com/bytedance/sonic/loader v0.1.1 h1:c+e5Pt1k/cy5wMveRDyk2X4B9hF4g7an8N3zCYjJFNM=

--- a/lib/chatops/chatops-interfaces.go
+++ b/lib/chatops/chatops-interfaces.go
@@ -1,6 +1,7 @@
 package chatops
 
 import (
+	"github.com/atc0005/go-teams-notify/v2/adaptivecard"
 	"github.com/pandatix/gocket-chat/api/chat"
 )
 
@@ -8,4 +9,5 @@ type ChatOpsInterface interface {
 	PostMessage(code int, target string) (*ChatOpsResponse, error)
 	slack(code int, target string) (*string, *string, error)
 	rocketChat(code int, target string) (*chat.PostMessageResponse, error)
+	teams(code int, target string, output interface{}) (*adaptivecard.Message, error)
 }

--- a/lib/chatops/chatops.go
+++ b/lib/chatops/chatops.go
@@ -27,7 +27,7 @@ type ChatAttachment struct {
 	Color      string
 }
 
-func (c *ChatOps) PostMessage(code int, target string) (*ChatOpsResponse, error) {
+func (c *ChatOps) PostMessage(code int, target string, output interface{}) (*ChatOpsResponse, error) {
 	var resp ChatOpsResponse
 
 	switch c.Service {
@@ -45,6 +45,11 @@ func (c *ChatOps) PostMessage(code int, target string) (*ChatOpsResponse, error)
 		}
 		resp.Channel = res.Channel
 		resp.Timestamp = strconv.FormatInt(res.Ts, 10)
+	case "teams":
+		_, err := c.teams(code, target, output)
+		if err != nil {
+			return nil, err
+		}
 	default:
 		return nil, fmt.Errorf("ChatOps tools `%s` is not supported at this time", c.Service)
 	}

--- a/lib/chatops/teams.go
+++ b/lib/chatops/teams.go
@@ -55,7 +55,7 @@ func (c *ChatOps) teams(code int, target string, output interface{}) (*adaptivec
 
 	// Change texts and add details button, depending on type of output (error, QueueItem, any)
 	switch fmt.Sprintf("%T", output) {
-	case "error":
+	case "*errors.errorString":
 		messageTextBlock = NewTextBlock(fmt.Sprintf("Error: %s", output), color)
 		details = false
 	case "*queue.QueueItem":
@@ -132,6 +132,7 @@ func ScanforWarn(output interface{}) bool {
 func getCaller() string {
 	var callerFunction string
 
+	// ignoring return values 'file name' and 'line number in that file', because those values are not needed
 	pc, _, _, ok := runtime.Caller(3)
 	runtimedetails := runtime.FuncForPC(pc)
 	if ok && runtimedetails != nil {

--- a/lib/chatops/teams.go
+++ b/lib/chatops/teams.go
@@ -1,0 +1,174 @@
+package chatops
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+
+	goteamsnotify "github.com/atc0005/go-teams-notify/v2"
+	"github.com/atc0005/go-teams-notify/v2/adaptivecard"
+	log "github.com/sirupsen/logrus"
+)
+
+// Sends a message to a webhook in Microsoft Teams. Returns AdaptiveCard message and error.
+func (c *ChatOps) teams(code int, target string, output interface{}) (*adaptivecard.Message, error) {
+	var color string
+	var status string
+	var messageTextBlock adaptivecard.Element
+	var detailsBlock adaptivecard.Element
+	var details bool
+
+	// Initialize a new Microsoft Teams client.
+	mstClient := goteamsnotify.NewTeamsClient()
+
+	// Set webhook url.
+	webhookUrl := *c.ServerURI
+
+	// Get caller function name (either module or environment).
+	callerFunction := getCaller()
+
+	// The title for message (first TextBlock element).
+	msgTitle := "Deploy " + callerFunction + " " + target
+
+	// Formatted message body.
+	msgText := "r10k output:\n\n" + fmt.Sprintf("%s", output)
+
+	// Create blank card.
+	card := adaptivecard.NewCard()
+
+	// Determine text color and status text
+	if code == 202 {
+		if ScanforWarn(output) {
+			color = adaptivecard.ColorWarning
+			status = "successful with Warnings"
+		} else {
+			color = adaptivecard.ColorGood
+			status = "successful"
+		}
+	} else {
+		color = adaptivecard.ColorAttention
+		status = "failed"
+	}
+
+	// Create title element.
+	headerTextBlock := NewTitleTextBlock(msgTitle, color)
+
+	// Change texts and add details button, depending on type of output (error, QueueItem, any)
+	switch fmt.Sprintf("%T", output) {
+	case "error":
+		messageTextBlock = NewTextBlock(fmt.Sprintf("Error: %s", output), color)
+		details = false
+	case "*queue.QueueItem":
+		messageTextBlock = NewTextBlock(fmt.Sprintf("%s %s added to queue", callerFunction, target), color)
+		details = false
+	default:
+		messageTextBlock = NewTextBlock(fmt.Sprintf("Deployment of %s %s", target, status), color)
+		details = true
+		detailsBlock = adaptivecard.NewHiddenTextBlock(msgText, true)
+		detailsBlock.ID = "detailsBlock"
+	}
+
+	// This grouping is used for convenience.
+	allTextBlocks := []adaptivecard.Element{
+		headerTextBlock,
+		messageTextBlock,
+	}
+
+	// Add "Details" button to hide/unhide detailed output.
+	if details {
+		allTextBlocks = append(allTextBlocks, detailsBlock)
+		toggleButton := adaptivecard.NewActionToggleVisibility("Details")
+		if err := toggleButton.AddTargetElement(nil, detailsBlock); err != nil {
+			log.Errorf(
+				"failed to add element ID to toggle button: %v",
+				err,
+			)
+			return nil, err
+		}
+
+		if err := card.AddAction(true, toggleButton); err != nil {
+			log.Errorf(
+				"failed to add toggle button action to card: %v",
+				err,
+			)
+			return nil, err
+		}
+	}
+
+	// Assemble card from all elements.
+	if err := card.AddElement(true, allTextBlocks...); err != nil {
+		log.Errorf(
+			"failed to add text blocks to card: %v",
+			err,
+		)
+		return nil, err
+	}
+
+	// Create new Message using Card as input.
+	msg, err := adaptivecard.NewMessageFromCard(card)
+	if err != nil {
+		log.Errorf("failed to create message from card: %v", err)
+		return nil, err
+	}
+
+	// If not testing, sende the message.
+	if !c.TestMode {
+		if err := mstClient.Send(webhookUrl, msg); err != nil {
+			log.Errorf("failed to send message: %v", err)
+			return nil, err
+		}
+	}
+
+	return msg, err
+}
+
+// Scans output for string "WARN". Returns true, if found.
+func ScanforWarn(output interface{}) bool {
+	asstring := fmt.Sprintf("%s", output)
+	return strings.Contains(asstring, "WARN")
+}
+
+// Gets caller function. Returns "environment", "module" or empty string.
+func getCaller() string {
+	var callerFunction string
+
+	pc, _, _, ok := runtime.Caller(3)
+	runtimedetails := runtime.FuncForPC(pc)
+	if ok && runtimedetails != nil {
+		splitStr := strings.Split(runtimedetails.Name(), ".")
+		switch splitStr[len(splitStr)-1] {
+		case "DeployEnvironment":
+			callerFunction = "environment"
+		case "DeployModule":
+			callerFunction = "module"
+		default:
+			callerFunction = ""
+		}
+	}
+	return callerFunction
+}
+
+// Creates title text block. Returns AdaptiveCard element.
+func NewTitleTextBlock(title string, color string) adaptivecard.Element {
+	return adaptivecard.Element{
+		Type:   adaptivecard.TypeElementTextBlock,
+		Wrap:   true,
+		Text:   title,
+		Style:  adaptivecard.TextBlockStyleHeading,
+		Size:   adaptivecard.SizeLarge,
+		Weight: adaptivecard.WeightBolder,
+		Color:  color,
+	}
+}
+
+// Creates text block. Returns AdaptiveCard element.
+func NewTextBlock(text string, color string) adaptivecard.Element {
+	textBlock := adaptivecard.Element{
+		Type:  adaptivecard.TypeElementTextBlock,
+		Wrap:  true,
+		Text:  text,
+		Color: color,
+	}
+
+	return textBlock
+}

--- a/lib/chatops/teams_test.go
+++ b/lib/chatops/teams_test.go
@@ -1,0 +1,116 @@
+package chatops
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/atc0005/go-teams-notify/v2/adaptivecard"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTeams(t *testing.T) {
+	t.Run("Teams Message Post", func(t *testing.T) {
+		serverURI := "https://example.webhook.office.com/webhook/xxx"
+		c := ChatOps{
+			Service:   "teams",
+			TestMode:  true,
+			ServerURI: &serverURI,
+		}
+
+		t.Run("Good module", func(t *testing.T) {
+			// test a successful message
+			msg, err := c.teams(202, "good_module", "things went well")
+
+			// Prepare message payload
+			msg.Prepare()
+
+			var data adaptivecard.Message
+			json.Unmarshal([]byte(msg.PrettyPrint()), &data)
+
+			assert.NoError(t, err, "should not error")
+
+			// assert header text
+			// two spaces in the text "Deploy  good_module", because calling function can't be determined
+			assert.Equal(t, data.Attachments[0].Content.Body[0].Text, "Deploy  good_module", `header should be "Deploy  good_module"`)
+			assert.Equal(t, data.Attachments[0].Content.Body[0].Color, "good", `header color should be "good"`)
+
+			// assert body text
+			assert.Equal(t, data.Attachments[0].Content.Body[1].Text, "Deployment of good_module successful", `body text should be "Deployment of good_module successful"`)
+			assert.Equal(t, data.Attachments[0].Content.Body[1].Color, "good", `body color should be "good"`)
+
+			// assert details text
+			assert.Equal(t, data.Attachments[0].Content.Body[2].Text, "r10k output:\n\nthings went well", `details text should be "r10k output:\n\nthings went well"`)
+		})
+		t.Run("Failed module", func(t *testing.T) {
+			// test a fail message
+			msg, err := c.teams(500, "fail_module", "something failed")
+
+			// Prepare message payload
+			msg.Prepare()
+
+			var data adaptivecard.Message
+			json.Unmarshal([]byte(msg.PrettyPrint()), &data)
+			// log.Print(msg.PrettyPrint())
+			// log.Print(data.Attachments[0].Content.Body[0].Text)
+
+			assert.NoError(t, err, "should not error")
+
+			// assert header text
+			// two spaces in the text "Deploy  fail_module", because calling function can't be determined
+			assert.Equal(t, data.Attachments[0].Content.Body[0].Text, "Deploy  fail_module", `header should be "Deploy  fail_module"`)
+			assert.Equal(t, data.Attachments[0].Content.Body[0].Color, "attention", `header color should be "attention"`)
+
+			// assert body text
+			assert.Equal(t, data.Attachments[0].Content.Body[1].Text, "Deployment of fail_module failed", `body text should be "Deployment of fail_module failed"`)
+			assert.Equal(t, data.Attachments[0].Content.Body[1].Color, "attention", `body color should be "attention"`)
+
+			// assert details text
+			assert.Equal(t, data.Attachments[0].Content.Body[2].Text, "r10k output:\n\nsomething failed", `details text should be "r10k output:\n\nsomething failed"`)
+		})
+		t.Run("Module with warnings", func(t *testing.T) {
+			// test a message with warning
+			msg, err := c.teams(202, "warn_module", "WARN -> there are warnings")
+
+			// Prepare message payload
+			msg.Prepare()
+
+			var data adaptivecard.Message
+			json.Unmarshal([]byte(msg.PrettyPrint()), &data)
+			// log.Print(msg.PrettyPrint())
+			// log.Print(data.Attachments[0].Content.Body[0].Text)
+
+			assert.NoError(t, err, "should not error")
+
+			// assert header text
+			// two spaces in the text "Deploy  warn_module", because calling function can't be determined
+			assert.Equal(t, data.Attachments[0].Content.Body[0].Text, "Deploy  warn_module", `header should be "Deploy  warn_module"`)
+			assert.Equal(t, data.Attachments[0].Content.Body[0].Color, "warning", `header color should be "attention"`)
+
+			// assert body text
+			assert.Equal(t, data.Attachments[0].Content.Body[1].Text, "Deployment of warn_module successful with Warnings", `body text should be "Deployment of warn_module successful with Warnings"`)
+			assert.Equal(t, data.Attachments[0].Content.Body[1].Color, "warning", `body color should be "attention"`)
+
+			// assert details text
+			assert.Equal(t, data.Attachments[0].Content.Body[2].Text, "r10k output:\n\nWARN -> there are warnings", `details text should be "r10k output:\n\nWARN -> there are warnings"`)
+		})
+		t.Run("Error", func(t *testing.T) {
+			// test an error state
+			msg, err := c.teams(500, "error_module", fmt.Errorf("an error occurred"))
+
+			// Prepare message payload
+			msg.Prepare()
+
+			var data adaptivecard.Message
+			json.Unmarshal([]byte(msg.PrettyPrint()), &data)
+
+			assert.NoError(t, err, "should not error")
+
+			// assert header text
+			// two spaces in the text "Deploy  warn_module", because calling function can't be determined
+			assert.Equal(t, data.Attachments[0].Content.Body[0].Text, "Deploy  error_module", `header should be "Deploy  error_module"`)
+			assert.Equal(t, data.Attachments[0].Content.Body[0].Color, "attention", `header color should be "attention"`)
+			assert.Equal(t, data.Attachments[0].Content.Body[1].Text, "Error: an error occurred", `body should be "Error: an error occurred"`)
+		})
+	})
+}

--- a/lib/queue/queue.go
+++ b/lib/queue/queue.go
@@ -121,12 +121,13 @@ func worker() {
 			log.Errorf("failed to execute local command `%s` with error: `%s` `%s`", job.Command, err, res)
 
 			if conf.ChatOps.Enabled {
-				conn.PostMessage(http.StatusInternalServerError, job.Name)
+				conn.PostMessage(http.StatusInternalServerError, job.Name, res)
 			}
 			job.State = "failed"
 			continue
 		}
 
+		conn.PostMessage(http.StatusAccepted, job.Name, res)
 		job.State = "success"
 	}
 }


### PR DESCRIPTION
This PR adds the ability to send notifications to Microsoft Teams. Currently Slack and RocketChat are supported.

The notifications are sent via an AdaptiveCard. The messages are colored: green for successful, red for errors and orange, if there are warnings in the r10k output.
The PostMessage function is extended to add the output of r10k hidden underneath a "Details" button.

This is the first time, I did something in Go. If there is something to improve, I'm happy for suggestions.