### PR TITLE
Use provided r10k command_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,12 @@ Type: bool
 Description: Run `puppet generate types` after updating an environment
 Default: `true`
 
+### `command_path`
+
+Type: `string`
+Description: Allow overriding the default path to r10k.
+Default: `/opt/puppetlabs/puppetserver/bin/r10k`
+
 ## Usage
 
 Webhook API provides following paths

--- a/api/environment.go
+++ b/api/environment.go
@@ -24,7 +24,7 @@ func (e EnvironmentController) DeployEnvironment(c *gin.Context) {
 	var branch string
 
 	// Set the base r10k command into a slice of strings
-	cmd := []string{"r10k", "deploy", "environment"}
+	cmd := []string{h.GetR10kCommand(), "deploy", "environment"}
 
 	// Get the configuration
 	conf := config.GetConfig()

--- a/api/module.go
+++ b/api/module.go
@@ -24,7 +24,7 @@ func (m ModuleController) DeployModule(c *gin.Context) {
 	var h helpers.Helper
 
 	// Set the base r10k command into a string slice
-	cmd := []string{"r10k", "deploy", "module"}
+	cmd := []string{h.GetR10kCommand(), "deploy", "module"}
 
 	// Get the configuration
 	conf := config.GetConfig()

--- a/lib/helpers/r10k-command.go
+++ b/lib/helpers/r10k-command.go
@@ -1,0 +1,14 @@
+package helpers
+
+import "github.com/voxpupuli/webhook-go/config"
+
+const Command = "r10k"
+
+func (h *Helper) GetR10kCommand() string {
+	conf := config.GetConfig().R10k
+	commandPath := conf.CommandPath
+	if commandPath == "" {
+		return Command
+	}
+	return commandPath
+}


### PR DESCRIPTION
Prior to this, the Config struct had a setting under the R10k struct called CommandPath that could be set in the config file, but was ignored as both places that would use it were hard coded to instead use the string `r10k`. This resulted in the application looking in the path for the r10k binary. A default is set in config.go also, but that seems to have also been ignored.

This fixes #152

Note: I think this should also have a test, but I don't know enough about writing tests in go to make one that works...