### PR TITLE
Allow legacy --puppetfile flag to be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,12 @@ Type: bool
 Description: Deploy modules in environments.
 Default: `true`
 
+### `use_legacy_puppetfile_flag`
+
+Type: bool
+Description: Use the legacy `--puppetfile` flag instead of `--modules`. This should only be used when your version of r10k doesn't support the newer flag.
+Default: `false`
+
 ### `generate_types`
 
 Type: bool

--- a/api/environment.go
+++ b/api/environment.go
@@ -63,7 +63,11 @@ func (e EnvironmentController) DeployEnvironment(c *gin.Context) {
 		cmd = append(cmd, "--generate-types")
 	}
 	if conf.R10k.DeployModules {
-		cmd = append(cmd, "--modules")
+		if conf.R10k.UseLegacyPuppetfileFlag {
+			cmd = append(cmd, "--puppetfile")
+		} else {
+			cmd = append(cmd, "--modules")
+		}
 	}
 
 	// Pass the command to the execute function and act on the result and any error

--- a/config/config.go
+++ b/config/config.go
@@ -35,14 +35,15 @@ type Config struct {
 		ServerUri string `mapstructure:"server_uri"`
 	} `mapstructure:"chatops"`
 	R10k struct {
-		CommandPath    string `mapstructure:"command_path"`
-		ConfigPath     string `mapstructure:"config_path"`
-		DefaultBranch  string `mapstructure:"default_branch"`
-		Prefix         string `mapstructure:"prefix"`
-		AllowUppercase bool   `mapstructure:"allow_uppercase"`
-		Verbose        bool   `mapstructure:"verbose"`
-		DeployModules  bool   `mapstructure:"deploy_modules"`
-		GenerateTypes  bool   `mapstructure:"generate_types"`
+		CommandPath             string `mapstructure:"command_path"`
+		ConfigPath              string `mapstructure:"config_path"`
+		DefaultBranch           string `mapstructure:"default_branch"`
+		Prefix                  string `mapstructure:"prefix"`
+		AllowUppercase          bool   `mapstructure:"allow_uppercase"`
+		Verbose                 bool   `mapstructure:"verbose"`
+		DeployModules           bool   `mapstructure:"deploy_modules"`
+		UseLegacyPuppetfileFlag bool   `mapstructure:"use_legacy_puppetfile_flag"`
+		GenerateTypes           bool   `mapstructure:"generate_types"`
 	} `mapstructure:"r10k"`
 }
 
@@ -88,6 +89,7 @@ func setDefaults(v *viper.Viper) *viper.Viper {
 	v.SetDefault("r10k.verbose", true)
 	v.SetDefault("r10k.deploy_modules", true)
 	v.SetDefault("r10k.generate_types", true)
+	v.SetDefault("r10k.use_legacy_puppetfile_flag", false)
 
 	return v
 }


### PR DESCRIPTION
This allows for utilizing the current version of webhook-go in
environments saddled with legacy versions of r10k that don't yet have
the new `--modules` flag.
